### PR TITLE
Implements RFC 7

### DIFF
--- a/org/all-prs.ts
+++ b/org/all-prs.ts
@@ -32,6 +32,11 @@ export const rfc5 = rfc("No PR is too small to warrant a paragraph or two of sum
   }
 })
 
+// https://github.com/artsy/artsy-danger/issues/7
+export const rfc7 = rfc("Hook commit contexts to GitHub PR/Issue labels", async () => {
+
+})
+
 // https://github.com/artsy/artsy-danger/issues/13
 export const rfc13 = rfc("Always ensure we assign someone, so that our Slackbot work correctly", () => {
   const pr = danger.github.pr

--- a/tests/rfc_7.test.ts
+++ b/tests/rfc_7.test.ts
@@ -2,12 +2,84 @@ jest.mock("danger", () => jest.fn())
 import * as danger from "danger"
 const dm = danger as any
 
-import { rfc13 } from "../org/all-prs"
+import { rfc7 } from "../org/all-prs"
 
 beforeEach(() => {
-  dm.danger = {}
+  dm.danger = {
+    git: {},
+    github: {
+      api: {
+        issues: {
+          getLabels: jest.fn(),
+          addLabels: jest.fn()
+        }
+      },
+      thisPR: {
+        owner: 'artsy',
+        repo: 'eigen',
+        number: 1234
+      }
+    }
+  }
 })
 
-it("does nothing", () => {
+it("bails without commit labels", () => {
+  dm.danger.git.commits = [
+    "Implementing something",
+    "Adding tests",
+    "Changelog entry"
+  ].map((message) => ({ message }))
+  return rfc7().then(() => {
+    expect(dm.danger.github.api.issues.getLabels).not.toHaveBeenCalled()
+  })
+})
 
+describe("with commit labels", () => {
+  beforeEach(() => {
+    dm.danger.git.commits = [
+      "[Auctions] Implementing something",
+      "[Auctions] Adding tests",
+      "[Oops] Changelog entry"
+    ].map((message) => ({ message }))
+  })
+
+  it("retrieves labels from the GitHub api", () => {
+    dm.danger.github.api.issues.getLabels.mockImplementationOnce(() => ({ data: [] }))
+    return rfc7().then(() => {
+      expect(dm.danger.github.api.issues.getLabels).toHaveBeenCalledWith({
+        owner: 'artsy', repo: 'eigen'
+      })
+    })
+  })
+
+  describe("with no matching GitHub labels", () => {
+    it("does not add any labels", () => {
+      dm.danger.github.api.issues.getLabels.mockImplementationOnce(() => ({
+        data: [
+          { name: "wontfix" },
+          { name: "Messaging" }
+        ]
+      }))
+      return rfc7().then(() => {
+        expect(dm.danger.github.api.issues.addLabels).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe("with matching GitHub labels", () => {
+    it("adds GitHub labels that match commit labels", () => {
+      dm.danger.github.api.issues.getLabels.mockImplementationOnce(() => ({
+        data: [
+          { name: "wontfix" },
+          { name: "Messaging" },
+          { name: "Auctions" }
+        ]
+      }))
+      return rfc7().then(() => {
+        expect(dm.danger.github.api.issues.addLabels).toHaveBeenCalledWith({
+          owner: 'artsy', repo: 'eigen', number: 1234, labels: ['Auctions']
+        })
+      })
+    })
+  })
 })

--- a/tests/rfc_7.test.ts
+++ b/tests/rfc_7.test.ts
@@ -1,0 +1,13 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import { rfc13 } from "../org/all-prs"
+
+beforeEach(() => {
+  dm.danger = {}
+})
+
+it("does nothing", () => {
+
+})


### PR DESCRIPTION
Fixes #7, based on [this work from Orta](https://github.com/danger/danger-js/issues/180#issuecomment-308386682). Possible addition: translate from shorthand to longhand labels (so a commit message like `[MSG] Implements inbox` would match the `Messaging` label. I'll take a look later today. 

There's probably some code golfing to do, so don't be shy about pointing out alternative syntax etc!