### PR TITLE
Fixes getContent call to GitHub.

### DIFF
--- a/org/all-prs.ts
+++ b/org/all-prs.ts
@@ -46,10 +46,10 @@ export const rfc16 = rfc("Require changelog entries on PRs with code changes", a
   const pr = danger.github.pr
   const changelogs = ["CHANGELOG.md", "changelog.md", "CHANGELOG.yml"]
 
-  const getContentParams = { path: "/", owner: pr.head.user.login, repo: pr.head.repo.name }
-  const rootContents: any[] = await danger.github.api.repos.getContent(getContentParams)
+  const getContentParams = { path: "", owner: pr.head.user.login, repo: pr.head.repo.name }
+  const rootContents: any = await danger.github.api.repos.getContent(getContentParams)
 
-  const hasChangelog = rootContents.find(file => changelogs.includes(file.name))
+  const hasChangelog = rootContents.data.find(file => changelogs.includes(file.name))
   if (hasChangelog) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]
 

--- a/tests/rfc_16.test.ts
+++ b/tests/rfc_16.test.ts
@@ -24,7 +24,7 @@ it("warns when code has changed but no changelog entry was made", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve([{ name: "code.js" }, { name: "CHANGELOG.md" }]),
+        getContent: () => Promise.resolve({ data: [{ name: "code.js" }, { name: "CHANGELOG.md" }] }),
       },
     },
     pr,
@@ -42,7 +42,7 @@ it("does nothing when there is no changelog file", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve([{ name: "code.js" }]),
+        getContent: () => Promise.resolve({ data: [{ name: "code.js" }] }),
       },
     },
     pr,
@@ -60,7 +60,7 @@ it("does nothing when only `test` files were changed", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve([{ name: "CHANGELOG.md" }]),
+        getContent: () => Promise.resolve({ data: [{ name: "CHANGELOG.md" }] }),
       },
     },
     pr,
@@ -78,7 +78,7 @@ it("does nothing when the changelog was changed", () => {
   dm.danger.github = {
     api: {
       repos: {
-        getContent: () => Promise.resolve([{ name: "code.js" }, { name: "CHANGELOG.md" }]),
+        getContent: () => Promise.resolve({ data: [{ name: "code.js" }, { name: "CHANGELOG.md" }] }),
       },
     },
     pr,


### PR DESCRIPTION
Broken by #23. For the root of the repo, path needs to be `''`, and returns an array wrapped in the `data` key.