### PR TITLE
Don't allow duplication of issues inside a PR

### DIFF
--- a/org/all-prs.ts
+++ b/org/all-prs.ts
@@ -35,16 +35,19 @@ export const rfc5 = rfc("No PR is too small to warrant a paragraph or two of sum
 // https://github.com/artsy/artsy-danger/issues/7
 export const rfc7 = rfc("Hook commit contexts to GitHub PR/Issue labels", async () => {
   const pr = danger.github.thisPR
-  const commitLabels = danger.git.commits
+  const commitLabels: string[] = danger.git.commits
     .map(c => c.message)
     .filter(m => m.startsWith("[") && m.includes("]"))
     .map(m => (m.match(/\[(.*)\]/) as any)[1]) // Guaranteed to match based on filter above.
+
   if (commitLabels.length > 0) {
     const api = danger.github.api
     const githubLabels = await api.issues.getLabels({ owner: pr.owner, repo: pr.repo })
-    const matchingLabels = githubLabels.data
-      .map((l: any) => l.name)
-      .filter((l: string) => commitLabels.find(cl => l === cl))
+    const matchingLabels = (githubLabels.data as { name: string }[])
+      .map(l => l.name)
+      .filter(l => commitLabels.find(cl => l === cl))
+      .filter(l => !danger.github.issue.labels.find(label => label.name === l))
+
     if (matchingLabels.length > 0) {
       await api.issues.addLabels({ owner: pr.owner, repo: pr.repo, number: pr.number, labels: matchingLabels })
     }


### PR DESCRIPTION
Re: #26 - I spotted that additional commits would trigger every events. You obviously can't add the same label twice, but GitHub still triggers an event in the stream, so that will get annoying quickly. 

I added some typing further up the mapping system, so that they flow through the mapping correctly 👍 