### PR TITLE
Update peril.settings.json to remove artsy/clouds

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "env_vars": ["SLACK_RFC_WEBHOOK_URL"],
-    "ignored_repos": ["artsy/looker"],
+    "ignored_repos": ["artsy/looker", "artsy/clouds"],
     "modules": ["danger-plugin-spellcheck", "danger-plugin-yarn", "@slack/client"]
   },
   "rules": {


### PR DESCRIPTION
It's being used for PRs, but not by an engineering team, so they shouldn't be held to the same rigor (today ;) )

/cc @mdole @cfinsness