### PR TITLE
Updates RFC16 to not run on a closed PR

### DIFF
--- a/org/all-prs.ts
+++ b/org/all-prs.ts
@@ -67,12 +67,13 @@ export const rfc13 = rfc("Always ensure we assign someone, so that our Slackbot 
 export const rfc16 = rfc("Require changelog entries on PRs with code changes", async () => {
   const pr = danger.github.pr
   const changelogs = ["CHANGELOG.md", "changelog.md", "CHANGELOG.yml"]
+  const isOpen = danger.github.pr.state === "open"
 
   const getContentParams = { path: "", owner: pr.head.user.login, repo: pr.head.repo.name }
   const rootContents: any = await danger.github.api.repos.getContent(getContentParams)
 
-  const hasChangelog = rootContents.data.find(file => changelogs.includes(file.name))
-  if (hasChangelog) {
+  const hasChangelog = rootContents.data.find((file: any) => changelogs.includes(file.name))
+  if (isOpen && hasChangelog) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]
 
     const hasCodeChanges = files.find(file => !file.match(/(test|spec)/i))

--- a/tests/rfc_16.test.ts
+++ b/tests/rfc_16.test.ts
@@ -18,6 +18,7 @@ const pr = {
       name: "danger-js",
     },
   },
+  state: "open",
 }
 
 it("warns when code has changed but no changelog entry was made", () => {
@@ -85,6 +86,24 @@ it("does nothing when the changelog was changed", () => {
   }
   dm.danger.git = {
     modified_files: ["src/index.html", "CHANGELOG.md"],
+    created_files: [],
+  }
+  return rfc16().then(() => {
+    expect(dm.warn).not.toBeCalled()
+  })
+})
+
+it("does not warns with a closed PR", () => {
+  dm.danger.github = {
+    api: {
+      repos: {
+        getContent: () => Promise.resolve({ data: [{ name: "code.js" }, { name: "CHANGELOG.md" }] }),
+      },
+    },
+    pr: { ...pr, state: "closed" },
+  }
+  dm.danger.git = {
+    modified_files: ["src/index.html"],
     created_files: [],
   }
   return rfc16().then(() => {


### PR DESCRIPTION
I occasionally see this check happening on closed PRs, which it definitely shouldn't do.