### PR TITLE
Update peril.settings.json to ignore the design repo

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "env_vars": ["SLACK_RFC_WEBHOOK_URL"],
-    "ignored_repos": ["artsy/looker", "artsy/clouds"],
+    "ignored_repos": ["artsy/looker", "artsy/clouds", "artsy/design"],
     "modules": ["danger-plugin-spellcheck", "danger-plugin-yarn", "@slack/client"]
   },
   "rules": {


### PR DESCRIPTION
They shouldn't be held up to the same level of process as engineering. /cc @briansw 